### PR TITLE
Enhance ElasticBLAST demo script by allowing custom log file name

### DIFF
--- a/submit-and-wait-for-results.sh
+++ b/submit-and-wait-for-results.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 # All ElasticBLAST configuration settings are specified in the config file
 CFG=${1}
 timeout_minutes=${2:-5}
+logfile=${3:-"elastic-blast.log"}
 set +e
 elb_results=`printenv ELB_RESULTS`
 set -e
@@ -25,7 +26,6 @@ fi
 
 DRY_RUN=''
 #DRY_RUN=--dry-run     # uncomment for debugging
-logfile=elastic-blast.log
 rm -f $logfile
 
 get_num_cores() {


### PR DESCRIPTION
This is to facilitate submitting (and waiting for) multiple ElasticBLAST
searches at once.
