### PR TITLE
If exit code is greater than 6, exit early

### DIFF
--- a/submit-and-wait-for-results.sh
+++ b/submit-and-wait-for-results.sh
@@ -90,8 +90,8 @@ attempts=0
 while [ $attempts -lt $timeout_minutes ]; do
     exit_code=0
     elastic-blast status --cfg $CFG $DRY_RUN --exit-code --logfile /dev/null || exit_code=$?
-    if [ $exit_code -eq 0 ] || [ $exit_code -eq 1 ] ; then
-	break
+    if [ $exit_code -eq 0 ] || [ $exit_code -eq 1 ] || [ $exit_code -ge 6 ] ; then
+        break
     fi
 
     attempts=$(($attempts+1))


### PR DESCRIPTION
If the return value of `elastic-blast status --exit-code` is greater than or
equal to 6 (`UNKNOWN` status), exit the waiting loop.
