### PR TITLE
Add bucket name to delete call

### DIFF
--- a/elastic-blast-rdrp.ipynb
+++ b/elastic-blast-rdrp.ipynb
@@ -887,7 +887,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!elastic-blast delete --cfg {conf_file}"
+    "!elastic-blast delete --cfg {conf_file} --results s3://{RESULTS_BUCKET}"
    ]
   },
   {


### PR DESCRIPTION
Delete command won't work without bucket name