### PR TITLE
Use consistent spelling for ElasticBLAST

### DIFF
--- a/elastic-blast-rdrp.ipynb
+++ b/elastic-blast-rdrp.ipynb
@@ -116,7 +116,7 @@
    "metadata": {},
    "source": [
     "## Optional: Enable ElasticBLAST Auto-shutdown feature\n",
-    "This feature enables ElasticBLAST to monitor its status and shutdown cloud resources in the event of failures or successful search completion. It needs to be done only once per AWS user. If this feature is not enables you will need to run `elastic-blast delete` to delete cloud resources. Please, see https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/janitor.html for more information. "
+    "This feature enables ElasticBLAST to monitor its status and shutdown cloud resources in the event of failures or successful search completion. It needs to be done only once per AWS user. If this feature is not enabled you will need to run `elastic-blast delete` to delete cloud resources. Please, see https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/janitor.html for more information. "
    ]
   },
   {
@@ -249,7 +249,7 @@
    "metadata": {},
    "source": [
     "## Download results\n",
-    "ElasticBLAST search is done and results are placed in your results bucket. Now we need to download the results to analyze then."
+    "ElasticBLAST search is done and results are placed in your results bucket. Now we need to download the results to analyze them."
    ]
   },
   {

--- a/elastic-blast-rdrp.ipynb
+++ b/elastic-blast-rdrp.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Use Elastic-BLAST to identify RdRp genes in a viral metagenome.\n",
+    "# Use ElasticBLAST to identify RdRp genes in a viral metagenome.\n",
     "\n",
     "In this notebook, we search WGS sequences from the Culex mosquito virome (JAIJZY01) against a BLAST database based on the supplementary materials of:\n",
     "\n",
@@ -41,7 +41,7 @@
    "metadata": {},
    "source": [
     "## Set up AWS credentials\n",
-    "You need to provide credentials for your AWS user account so that Elastic-BLAST can use cloud resources. Generating and providing user credentials is described here: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html. There are two steps to this process:\n",
+    "You need to provide credentials for your AWS user account so that ElasticBLAST can use cloud resources. Generating and providing user credentials is described here: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html. There are two steps to this process:\n",
     "1. Create AWS access keys via AWS console: https://console.aws.amazon.com/iam/\n",
     "1. Paste AWS access key and AWS secret access key in the code below (remember to use quotes as these are python strings)\n",
     "\n",
@@ -64,7 +64,7 @@
    "metadata": {},
    "source": [
     "## Create results bucket (if one does not exist)\n",
-    "Elastic-BLAST saves results in a cloud bucket. If you already have a cloud bucket in AWS, you can just provide its name."
+    "ElasticBLAST saves results in a cloud bucket. If you already have a cloud bucket in AWS, you can just provide its name."
    ]
   },
   {
@@ -115,7 +115,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Optional: Enable Elastic-BLAST Auto-shutdown feature\n",
+    "## Optional: Enable ElasticBLAST Auto-shutdown feature\n",
     "This feature enables ElasticBLAST to monitor its status and shutdown cloud resources in the event of failures or successful search completion. It needs to be done only once per AWS user. If this feature is not enables you will need to run `elastic-blast delete` to delete cloud resources. Please, see https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/janitor.html for more information. "
    ]
   },
@@ -133,8 +133,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Elastic-BLAST configuration file\n",
-    "For easier code management we will assign the Elastic-BLAST configuration file name to the variable `conf_file`."
+    "## ElasticBLAST configuration file\n",
+    "For easier code management we will assign the ElasticBLAST configuration file name to the variable `conf_file`."
    ]
   },
   {
@@ -150,9 +150,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below is the contents of Elastic-BLAST configuration file, and running the cell below will write it to file `JAIJZY.ini`.\n",
+    "Below is the contents of ElasticBLAST configuration file, and running the cell below will write it to file `JAIJZY.ini`.\n",
     "\n",
-    "This configuration file instructs Elastic-BLAST to run a BLASTX search of query sequences stored in `s3://elasticblast-test/queries/JAIJZY01.1.fsa_nt.gz` against the database `s3://elasticblast-test/db/wolf18/RNAvirome.S2.RDRP`.  RNAvirome.S2.RDRP was derived from supplementary materials attached to Wolf et al."
+    "This configuration file instructs ElasticBLAST to run a BLASTX search of query sequences stored in `s3://elasticblast-test/queries/JAIJZY01.1.fsa_nt.gz` against the database `s3://elasticblast-test/db/wolf18/RNAvirome.S2.RDRP`.  RNAvirome.S2.RDRP was derived from supplementary materials attached to Wolf et al."
    ]
   },
   {
@@ -188,8 +188,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Submit Elastic-BLAST search\n",
-    "Run the cell below to submit an Elastic-BLAST search. It will take a few minutes."
+    "## Submit ElasticBLAST search\n",
+    "Run the cell below to submit an ElasticBLAST search. It will take a few minutes."
    ]
   },
   {
@@ -215,7 +215,7 @@
    "metadata": {},
    "source": [
     "## Check search status\n",
-    "The cell below checks search status. Elastic-BLAST splits query sequences into batches. _elastic-blast status_ command shows how many of these batches are pending, running, completed, or completed. When the whole search is done you will see only the message: \"Your Elastic-BLAST search succeeded ...\" or \"Your Elastic-BLAST search failed ...\""
+    "The cell below checks search status. ElasticBLAST splits query sequences into batches. _elastic-blast status_ command shows how many of these batches are pending, running, completed, or completed. When the whole search is done you will see only the message: \"Your ElasticBLAST search succeeded ...\" or \"Your ElasticBLAST search failed ...\""
    ]
   },
   {
@@ -232,7 +232,7 @@
    "metadata": {},
    "source": [
     "## Wait until the search is done\n",
-    "Run the cell below to wait until the search is done. The cell will keep working until Elastic-BLAST search is complete."
+    "Run the cell below to wait until the search is done. The cell will keep working until ElasticBLAST search is complete."
    ]
   },
   {
@@ -249,7 +249,7 @@
    "metadata": {},
    "source": [
     "## Download results\n",
-    "Elastic-BLAST search is done and results are placed in your results bucket. Now we need to download the results to analyze then."
+    "ElasticBLAST search is done and results are placed in your results bucket. Now we need to download the results to analyze then."
    ]
   },
   {
@@ -284,7 +284,7 @@
    "metadata": {},
    "source": [
     "## Uncompress and merge results\n",
-    "Elastic-BLAST produces compressed result files for each batch of queries. We are going to uncompress them, merge them into one file: `results.tab`, and show its first few lines."
+    "ElasticBLAST produces compressed result files for each batch of queries. We are going to uncompress them, merge them into one file: `results.tab`, and show its first few lines."
    ]
   },
   {
@@ -877,8 +877,8 @@
    "metadata": {},
    "source": [
     "## Clean up cloud resources\n",
-    "### Delete Elastic-BLAST queue and compute environment in AWS\n",
-    "If you did not enable Elastic-BLAST auto-shutdown feature, the AWS Batch queue and compute environment have to be deleted manually."
+    "### Delete ElasticBLAST queue and compute environment in AWS\n",
+    "If you did not enable ElasticBLAST auto-shutdown feature, the AWS Batch queue and compute environment have to be deleted manually."
    ]
   },
   {
@@ -912,7 +912,7 @@
    "metadata": {},
    "source": [
     "## Optional: Delete elastic-blast-janitor role\n",
-    "Deleting this role will disable Elastic-BLAST auto-shutdown feature. You are not paying for this role. It can be reused in future Elastic-BLAST searches."
+    "Deleting this role will disable ElasticBLAST auto-shutdown feature. You are not paying for this role. It can be reused in future ElasticBLAST searches."
    ]
   },
   {


### PR DESCRIPTION
For consistency, spell ElasticBLAST (the product) in the same way it's spelled in its
documentation (https://blast.ncbi.nlm.nih.gov/doc/elastic-blast/).
